### PR TITLE
do not stop FW early in first iteration

### DIFF
--- a/examples/worst-case.jl
+++ b/examples/worst-case.jl
@@ -72,4 +72,8 @@ const diffw = 0.5 * ones(n) + Random.rand(n)* alpha * 1/n
     @test f(x) <= f(result[:raw_solution])
     println("\nNumber of processed nodes should be: ", 2^(n+1)-1)
     println()
+
+    # test if number of nodes is still correct when stopping FW early
+    x, _, result = Boscia.solve(f, grad!, lmo, verbose = false, min_number_lower=5)
+    @test result[:number_nodes] ==  2^(n+1)-1
 end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -47,7 +47,7 @@ function build_FW_callback(tree, min_number_lower, check_rounding_value::Bool, f
             Bonobo.bound!(tree, node.id)
         end
 
-        if !isempty(tree.nodes) && min_number_lower <= length(values(tree.nodes))
+        if state.t > 1 && !isempty(tree.nodes) && min_number_lower <= length(values(tree.nodes))
             counter = 0
             for n in values(tree.nodes)
                 if n.lb < val


### PR DESCRIPTION
Do not stop FW in the first iteration, otherwise the active set contains often exactly one integer vertex , wherefore we do not split on that node as the relaxed_value corresponds to the active set.