### PR TITLE
Fixing the FW callback

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,5 +1,5 @@
 # FW callback
-function build_FW_callback(tree, min_number_lower, check_rounding_value::Bool, fw_iterations)
+function build_FW_callback(tree, min_number_lower, check_rounding_value::Bool, fw_iterations, min_fw_iterations)
     vars = [MOI.VariableIndex(var) for var in 1:tree.root.problem.nvars]
     # variable to only fetch heuristics when the counter increases
     ncalls = -1
@@ -28,7 +28,7 @@ function build_FW_callback(tree, min_number_lower, check_rounding_value::Bool, f
             end
         end
 
-        if (state.primal - state.dual_gap > tree.incumbent)
+        if (state.primal - state.dual_gap > tree.incumbent + 1e-2) && tree.num_nodes != 1 && state.t > min_fw_iterations
             return false
         end
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -62,7 +62,7 @@ function build_FW_callback(tree, min_number_lower, check_rounding_value::Bool, f
             end
         end
 
-        if check_rounding_value && state.tt == FrankWolfe.last
+        if check_rounding_value && state.tt == FrankWolfe.pp
             # round values
             x_rounded = copy(state.x)
             for idx in tree.branching_indices

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -22,6 +22,7 @@ max_fw_iter           - maximum number of iterations ina FrankWolfe run.
 min_number_lower      - If not Inf, evaluation of a node is stopped if at least min_number_lower nodes have a better 
                         lower bound.
 min_node_fw_epsilon   - smallest fw epsilon possible, see dual_gap_decay_factor.
+min_fw_iterations     - the minimum number of FrankWolfe iterations in the node evaluation. 
 """
 function solve(
     f,
@@ -40,6 +41,7 @@ function solve(
     min_number_lower=Inf,
     min_node_fw_epsilon=1e-6,
     use_postsolve = true,
+    min_fw_iterations = 5,
     kwargs...,
 )
     if verbose
@@ -190,7 +192,7 @@ function solve(
         node_level,
     )
 
-    fw_callback = build_FW_callback(tree, min_number_lower, true, fw_iterations)
+    fw_callback = build_FW_callback(tree, min_number_lower, true, fw_iterations, min_fw_iterations)
 
     tree.root.options[:callback] = fw_callback
     tree.root.current_node_id[] = Bonobo.get_next_node(tree, tree.options.traverse_strategy).id

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -513,7 +513,7 @@ function postsolve(tree, result, time_ref, verbose, use_postsolve)
         )
 
         # update tree
-        @assert primal <= tree.incumbent + 1e-5
+        @assert primal <= tree.incumbent + 1e-2
         if primal < tree.incumbent
             tree.root.updated_incumbent[] = true
             tree.incumbent = primal

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -139,10 +139,6 @@ function is_linear_feasible_subroutine(o::MOI.ModelLike, ::Type{F}, ::Type{S}, v
             scip_tol = MOI.get(o, MOI.RawOptimizerAttribute("numerics/feastol"))
         end
         if dist > 50.0 * scip_tol
-           #= if dist < 5e-2
-                @warn "Point not linear feasible. Distance to set: $(dist)"
-                return true
-            end=#
             @debug("Constraint: $(F)-$(S) $(func) = $(val) in $(set)")
             @debug("Distance to set: $(dist)")
             return false

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -139,10 +139,10 @@ function is_linear_feasible_subroutine(o::MOI.ModelLike, ::Type{F}, ::Type{S}, v
             scip_tol = MOI.get(o, MOI.RawOptimizerAttribute("numerics/feastol"))
         end
         if dist > 50.0 * scip_tol
-            if dist < 5e-2
+           #= if dist < 5e-2
                 @warn "Point not linear feasible. Distance to set: $(dist)"
                 return true
-            end
+            end=#
             @debug("Constraint: $(F)-$(S) $(func) = $(val) in $(set)")
             @debug("Distance to set: $(dist)")
             return false

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -139,7 +139,7 @@ function is_linear_feasible_subroutine(o::MOI.ModelLike, ::Type{F}, ::Type{S}, v
             scip_tol = MOI.get(o, MOI.RawOptimizerAttribute("numerics/feastol"))
         end
         if dist > 50.0 * scip_tol
-            if dist < 1.0
+            if dist < 5e-2
                 @warn "Point not linear feasible. Distance to set: $(dist)"
                 return true
             end


### PR DESCRIPTION
1. The rounding of the solution was only done if the verbose setting of FrankWolfe was on. The rounding should happen in the post processing step in FW.
2. In the node evaluation, we sometimes stop prematurely. The incumbent is quite good already and the first few FW iterations rather coarse. 