### PR TITLE
Fix DocString Warning

### DIFF
--- a/src/managed_blmo.jl
+++ b/src/managed_blmo.jl
@@ -12,10 +12,10 @@ Computes the extreme point given an direction d, the current lower and upper bou
 function bounded_compute_extreme_point end
 
 """
-Checks whether a given point v is satisfying the linear constraints on the problem.
+Checks whether a given point v is satisfying the constraints on the problem.
 Note that the bounds on the integer variables are being checked by the ManagedBoundedLMO and do not have to be check here. 
 """
-function is_linear_feasible end
+function is_simple_linear_feasible end
 
 
 """
@@ -179,7 +179,7 @@ function is_linear_feasible(blmo::ManagedBoundedLMO, v::AbstractVector)
             return false
         end
     end
-    return is_linear_feasible(blmo.simple_lmo, v)
+    return is_simple_linear_feasible(blmo.simple_lmo, v)
 end
 
 # Has variable an integer constraint?

--- a/src/polytope_blmos.jl
+++ b/src/polytope_blmos.jl
@@ -25,7 +25,7 @@ function bounded_compute_extreme_point(sblmo::CubeSimpleBLMO, d, lb, ub, int_var
     return v
 end
 
-function is_linear_feasible(sblmo::CubeSimpleBLMO, v)
+function is_simple_linear_feasible(sblmo::CubeSimpleBLMO, v)
     for i in setdiff(eachindex(v), sblmo.int_vars)
         if !(sblmo.lower_bounds[i] ≤ v[i] + 1e-6 || !(v[i] - 1e-6 ≤ blmo.upper_bounds[i]))
             @debug(
@@ -68,7 +68,7 @@ function bounded_compute_extreme_point(sblmo::ProbabilitySimplexSimpleBLMO, d, l
     return v
 end
 
-function is_linear_feasible(sblmo::ProbabilitySimplexSimpleBLMO, v)
+function is_simple_linear_feasible(sblmo::ProbabilitySimplexSimpleBLMO, v)
     if sum(v .≥ 0) < length(v)
         @debug "v has negative entries: $(v)"
         return false
@@ -111,7 +111,7 @@ function bounded_compute_extreme_point(sblmo::UnitSimplexSimpleBLMO, d, lb, ub, 
     return v
 end
 
-function is_linear_feasible(sblmo::UnitSimplexSimpleBLMO, v)
+function is_simple_linear_feasible(sblmo::UnitSimplexSimpleBLMO, v)
     if sum(v .≥ 0) < length(v)
         @debug "v has negative entries: $(v)"
         return false


### PR DESCRIPTION
The issue was that the abstract function `is_linear_feasible` existed twice with different explanations.

One was for the `BoundedLinearMinimizationOracle`, the other for `SimpleBoundedLMO`. By that the two do sightly different things, as the `is_linear_feasible`of the `SimpleBoundedLMO` is a subroutine of `is_linear_feasible` function for the `ManagedBoundedLMO`.

Renamed it to `is_simple_linear_feasible`.