### PR TITLE
Logic fix for the rounding heuristic of the Probability Simplex

### DIFF
--- a/src/polytope_blmos.jl
+++ b/src/polytope_blmos.jl
@@ -94,7 +94,7 @@ function rounding_hyperplane_heuristic(tree::Bonobo.BnBTree, tlmo::TimeTrackingL
         z[idx] = round(x[idx])
     end
 
-    if sum(iszero.(z)) == length(z)
+    if sum(iszero.(z[tree.branching_indices])) == length(z[tree.branching_indices])
         return [z], false
     end
     

--- a/src/polytope_blmos.jl
+++ b/src/polytope_blmos.jl
@@ -93,6 +93,10 @@ function rounding_hyperplane_heuristic(tree::Bonobo.BnBTree, tlmo::TimeTrackingL
     for idx in tree.branching_indices
         z[idx] = round(x[idx])
     end
+
+    if sum(iszero.(z)) == length(z)
+        return [z], false
+    end
     
     N = tlmo.blmo.simple_lmo.N
     if sum(z) < N

--- a/src/polytope_blmos.jl
+++ b/src/polytope_blmos.jl
@@ -94,7 +94,7 @@ function rounding_hyperplane_heuristic(tree::Bonobo.BnBTree, tlmo::TimeTrackingL
         z[idx] = round(x[idx])
     end
 
-    if sum(iszero.(z[tree.branching_indices])) == length(z[tree.branching_indices])
+    if count(!iszero, z[tree.branching_indices]) == 0
         return [z], false
     end
     


### PR DESCRIPTION
In the hyperplane-aware rounding heuristic for the Probability Simplex, it can happen that the rounded point as all zero entries for the integer variables. In which case, we just return the point but let the feasibility check run.