### PR TITLE
Clip in probability rounding

### DIFF
--- a/src/heuristics.jl
+++ b/src/heuristics.jl
@@ -128,7 +128,7 @@ function probability_rounding(tree::Bonobo.BnBTree, tlmo::Boscia.TimeTrackingLMO
 
     bounds = IntegerBounds()
     for (i,x_i) in zip(tlmo.blmo.int_vars, x[tlmo.blmo.int_vars])
-        x_rounded = flip_coin(x_i, rng) ? ceil(x_i) : floor(x_i)
+        x_rounded = flip_coin(x_i, rng) ? min(1.0, ceil(x_i)) : max(0.0, floor(x_i))
         push!(bounds, (i, x_rounded), :lessthan)
         push!(bounds, (i, x_rounded), :greaterthan)
     end

--- a/src/tightenings.jl
+++ b/src/tightenings.jl
@@ -41,7 +41,7 @@ function dual_tightening(tree, node, x, dual_gap)
                         end
                     end
                     if bound_tightened
-                        new_bound = lb + Mlb - 1
+                        new_bound = max(lb + Mlb - 1, tree.root.problem.integer_variable_bounds[j, :greaterthan])
                         @debug "found UB tightening $ub -> $new_bound"
                         node.local_bounds[j, :lessthan] = new_bound
                         num_tightenings += 1
@@ -67,7 +67,7 @@ function dual_tightening(tree, node, x, dual_gap)
                         end
                     end
                     if bound_tightened
-                        new_bound = ub - Mub + 1
+                        new_bound = min(ub - Mub + 1, tree.root.problem.integer_variable_bounds[j, :lessthan])
                         @debug "found LB tightening $lb -> $new_bound"
                         node.local_bounds[j, :greaterthan] = new_bound
                         num_tightenings += 1


### PR DESCRIPTION
We fix the variables by flipping a coin:
```
x_rounded = flip_coin(x_i, rng) ? ceil(x_i) : floor(x_i)
```
Due to numerics, it can happen that `x_i \approx e-16` or `x_i \approx 1+2e-16`. Hence, we need to clip in the rounding.