### PR TITLE
Condtional dual tightening

### DIFF
--- a/src/heuristics.jl
+++ b/src/heuristics.jl
@@ -128,7 +128,7 @@ function probability_rounding(tree::Bonobo.BnBTree, tlmo::Boscia.TimeTrackingLMO
 
     bounds = IntegerBounds()
     for (i,x_i) in zip(tlmo.blmo.int_vars, x[tlmo.blmo.int_vars])
-        x_rounded = flip_coin(x_i, rng) ? ceil(x_i) : floor(x_i)
+        x_rounded = flip_coin(x_i, rng) ? min(1.0, ceil(x_i)) : max(0.0, floor(x_i))
         push!(bounds, (i, x_rounded), :lessthan)
         push!(bounds, (i, x_rounded), :greaterthan)
     end

--- a/src/tightenings.jl
+++ b/src/tightenings.jl
@@ -31,7 +31,6 @@ function dual_tightening(tree, node, x, dual_gap)
                     continue
                 end
                 gj = grad[j]
-           
                 if ≈(x[j], lb, atol=tree.options.atol, rtol=tree.options.rtol)
                     if !isapprox(gj, 0, atol=1e-5)
                         num_potential_tightenings += 1

--- a/src/tightenings.jl
+++ b/src/tightenings.jl
@@ -18,77 +18,76 @@ function dual_tightening(tree, node, x, dual_gap)
         if rhs < 0
             @debug "Skipping tightening because rhs is negative: $rhs"
             return
-        else
-            for j in tree.root.problem.integer_variables
-                lb_global = get(tree.root.problem.integer_variable_bounds, (j, :greaterthan), -Inf)
-                ub_global = get(tree.root.problem.integer_variable_bounds, (j, :lessthan), Inf)
-                lb = get(node.local_bounds.lower_bounds, j, lb_global)
-                ub = get(node.local_bounds.upper_bounds, j, ub_global)
-                @assert lb >= lb_global
-                @assert ub <= ub_global
-                if lb ≈ ub
-                    # variable already fixed
-                    continue
+        end
+        for j in tree.root.problem.integer_variables
+            lb_global = get(tree.root.problem.integer_variable_bounds, (j, :greaterthan), -Inf)
+            ub_global = get(tree.root.problem.integer_variable_bounds, (j, :lessthan), Inf)
+            lb = get(node.local_bounds.lower_bounds, j, lb_global)
+            ub = get(node.local_bounds.upper_bounds, j, ub_global)
+            @assert lb >= lb_global
+            @assert ub <= ub_global
+            if lb ≈ ub
+                # variable already fixed
+                continue
+            end
+            gj = grad[j]
+            if ≈(x[j], lb, atol=tree.options.atol, rtol=tree.options.rtol)
+                if !isapprox(gj, 0, atol=1e-5)
+                    num_potential_tightenings += 1
                 end
-                gj = grad[j]
-                if ≈(x[j], lb, atol=tree.options.atol, rtol=tree.options.rtol)
-                    if !isapprox(gj, 0, atol=1e-5)
-                        num_potential_tightenings += 1
-                    end
-                    if gj > 0
-                        Mlb = 0
-                        bound_tightened = true
-                        @debug "starting tightening ub $(rhs)"
-                        while 0.99 * (Mlb * gj + μ / 2 * Mlb^2) <= rhs
-                            Mlb += 1
-                            if lb + Mlb - 1 == ub
-                                bound_tightened = false
-                                break
-                            end
-                        end
-                        if bound_tightened
-                            new_bound = lb + Mlb - 1
-                            @debug "found UB tightening $ub -> $new_bound"
-                            node.local_bounds[j, :lessthan] = new_bound
-                            num_tightenings += 1
-                            if haskey(tree.root.problem.integer_variable_bounds, (j, :lessthan))
-                                @assert node.local_bounds[j, :lessthan] <=
-                                        tree.root.problem.integer_variable_bounds[j, :lessthan]
-                            end
+                if gj > 0
+                    Mlb = 0
+                    bound_tightened = true
+                    @debug "starting tightening ub $(rhs)"
+                    while 0.99 * (Mlb * gj + μ / 2 * Mlb^2) <= rhs
+                        Mlb += 1
+                        if lb + Mlb - 1 == ub
+                            bound_tightened = false
+                            break
                         end
                     end
-                elseif ≈(x[j], ub, atol=tree.options.atol, rtol=tree.options.rtol)
-                    if !isapprox(gj, 0, atol=1e-5)
-                        num_potential_tightenings += 1
-                    end
-                    if gj < 0
-                        Mub = 0
-                        bound_tightened = true
-                        @debug "starting tightening lb $(rhs)"
-                        while -0.99 * (Mub * gj + μ / 2 * Mub^2) <= rhs
-                            Mub += 1
-                            if ub - Mub + 1 == lb
-                                bound_tightened = false
-                                break
-                            end
+                    if bound_tightened
+                        new_bound = lb + Mlb - 1
+                        @debug "found UB tightening $ub -> $new_bound"
+                        node.local_bounds[j, :lessthan] = new_bound
+                        num_tightenings += 1
+                        if haskey(tree.root.problem.integer_variable_bounds, (j, :lessthan))
+                            @assert node.local_bounds[j, :lessthan] <=
+                                    tree.root.problem.integer_variable_bounds[j, :lessthan]
                         end
-                        if bound_tightened
-                            new_bound = ub - Mub + 1
-                            @debug "found LB tightening $lb -> $new_bound"
-                            node.local_bounds[j, :greaterthan] = new_bound
-                            num_tightenings += 1
-                            if haskey(tree.root.problem.integer_variable_bounds, (j, :greaterthan))
-                                @assert node.local_bounds[j, :greaterthan] >=
-                                        tree.root.problem.integer_variable_bounds[j, :greaterthan]
-                            end
+                    end
+                end
+            elseif ≈(x[j], ub, atol=tree.options.atol, rtol=tree.options.rtol)
+                if !isapprox(gj, 0, atol=1e-5)
+                    num_potential_tightenings += 1
+                end
+                if gj < 0
+                    Mub = 0
+                    bound_tightened = true
+                    @debug "starting tightening lb $(rhs)"
+                    while -0.99 * (Mub * gj + μ / 2 * Mub^2) <= rhs
+                        Mub += 1
+                        if ub - Mub + 1 == lb
+                            bound_tightened = false
+                            break
+                        end
+                    end
+                    if bound_tightened
+                        new_bound = ub - Mub + 1
+                        @debug "found LB tightening $lb -> $new_bound"
+                        node.local_bounds[j, :greaterthan] = new_bound
+                        num_tightenings += 1
+                        if haskey(tree.root.problem.integer_variable_bounds, (j, :greaterthan))
+                            @assert node.local_bounds[j, :greaterthan] >=
+                                    tree.root.problem.integer_variable_bounds[j, :greaterthan]
                         end
                     end
                 end
             end
-            @debug "# tightenings $num_tightenings"
-            node.local_tightenings = num_tightenings
-            node.local_potential_tightenings = num_potential_tightenings
         end
+        @debug "# tightenings $num_tightenings"
+        node.local_tightenings = num_tightenings
+        node.local_potential_tightenings = num_potential_tightenings
     end
 end
 

--- a/src/tightenings.jl
+++ b/src/tightenings.jl
@@ -41,7 +41,7 @@ function dual_tightening(tree, node, x, dual_gap)
                         end
                     end
                     if bound_tightened
-                        new_bound = max(lb + Mlb - 1, tree.root.problem.integer_variable_bounds[j, :greaterthan])
+                            new_bound = lb + Mlb - 1
                         @debug "found UB tightening $ub -> $new_bound"
                         node.local_bounds[j, :lessthan] = new_bound
                         num_tightenings += 1
@@ -67,7 +67,7 @@ function dual_tightening(tree, node, x, dual_gap)
                         end
                     end
                     if bound_tightened
-                        new_bound = min(ub - Mub + 1, tree.root.problem.integer_variable_bounds[j, :lessthan])
+                            new_bound = ub - Mub + 1
                         @debug "found LB tightening $lb -> $new_bound"
                         node.local_bounds[j, :greaterthan] = new_bound
                         num_tightenings += 1

--- a/src/tightenings.jl
+++ b/src/tightenings.jl
@@ -41,7 +41,7 @@ function dual_tightening(tree, node, x, dual_gap)
                         end
                     end
                     if bound_tightened
-                        new_bound = lb + Mlb - 1
+                        new_bound = max(lb + Mlb - 1, tree.root.problem.integer_variable_bounds[j, :greaterthan])
                         @debug "found UB tightening $ub -> $new_bound"
                         node.local_bounds[j, :lessthan] = new_bound
                         num_tightenings += 1
@@ -67,7 +67,7 @@ function dual_tightening(tree, node, x, dual_gap)
                         end
                     end
                     if bound_tightened
-                        new_bound = ub - Mub + 1
+                        new_bound = min(ub - Mub + 1, tree.root.problem.integer_variable_bounds[j, :lessthan])
                         @debug "found LB tightening $lb -> $new_bound"
                         node.local_bounds[j, :greaterthan] = new_bound
                         num_tightenings += 1

--- a/src/tightenings.jl
+++ b/src/tightenings.jl
@@ -8,6 +8,17 @@ function dual_tightening(tree, node, x, dual_gap)
         num_tightenings = 0
         num_potential_tightenings = 0
         μ = tree.root.options[:strong_convexity]
+        safety_tolerance = 2.0
+        rhs =
+            tree.incumbent - tree.root.problem.f(x) +
+            safety_tolerance * dual_gap +
+            sqrt(eps(tree.incumbent))
+        # If rhs is negative, we are either very close to the incumbent
+        # or f(x) is actually larger than the incumbent.
+        if rhs < 0
+            @debug "Skipping tightening because rhs is negative: $rhs"
+            return
+        else
             for j in tree.root.problem.integer_variables
                 lb_global = get(tree.root.problem.integer_variable_bounds, (j, :greaterthan), -Inf)
                 ub_global = get(tree.root.problem.integer_variable_bounds, (j, :lessthan), Inf)
@@ -20,11 +31,7 @@ function dual_tightening(tree, node, x, dual_gap)
                     continue
                 end
                 gj = grad[j]
-            safety_tolerance = 2.0
-            rhs =
-                tree.incumbent - tree.root.problem.f(x) +
-                safety_tolerance * dual_gap +
-                sqrt(eps(tree.incumbent))
+           
                 if ≈(x[j], lb, atol=tree.options.atol, rtol=tree.options.rtol)
                     if !isapprox(gj, 0, atol=1e-5)
                         num_potential_tightenings += 1


### PR DESCRIPTION
If the `rhs = tree.incumbent - tree.root.problem.f(x) + safety_tolerance * dual_gap + sqrt(eps(tree.incumbent))` is negative, tightening make no sense. Either the lower bound of the node is very close to the incumbent or in fact larger, so the node would be pruned anyway.