### PR TITLE
User defined stop

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -383,6 +383,8 @@ function postsolve(tree, result, time_ref, verbose, max_iteration_post)
         status_string = "Time limit reached"
     elseif tree.root.problem.solving_stage == NODE_LIMIT_REACHED
         status_string = "Node limit reached"
+    elseif tree.root.problem.solving_stage == USER_STOP
+        status_string = "User defined stop"
     else
         status_string = "Optimal (tolerance reached)"
         tree.root.problem.solving_stage = OPT_GAP_REACHED
@@ -457,6 +459,7 @@ function postsolve(tree, result, time_ref, verbose, max_iteration_post)
     total_time_in_sec = (Dates.value(Dates.now() - time_ref)) / 1000.0
     result[:total_time_in_sec] = total_time_in_sec
     result[:status] = status_string
+    result[:solving_stage] = tree.root.problem.solving_stage
 
     if verbose
         println()

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -7,6 +7,7 @@ Enum for the solving stage
     OPT_TREE_EMPTY = 2
     TIME_LIMIT_REACHED = 3
     NODE_LIMIT_REACHED = 4
+    USER_STOP = 5
 end
 
 """

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -338,7 +338,7 @@ Checks if the branch and bound can be stopped.
 By default (in Bonobo) stops then the priority queue is empty. 
 """
 function Bonobo.terminated(tree::Bonobo.BnBTree{<:FrankWolfeNode})
-    if tree.root.problem.solving_stage in (TIME_LIMIT_REACHED, NODE_LIMIT_REACHED)
+    if tree.root.problem.solving_stage in (TIME_LIMIT_REACHED, NODE_LIMIT_REACHED, USER_STOP)
         return true
     end
     absgap = tree.incumbent - tree.lb


### PR DESCRIPTION
Add a solving stage option that defines a user stop, `Boccia.USER_STOP`.

The user can set the `tree.root.problem.solving_stage` to this new flag in the `bnb_callback`. The solution process will be stopped afterwards.