### PR TITLE
Fix the size of active set and shadow set reported

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -111,14 +111,6 @@ function process_FW_callback_logic(
 
     node = tree.nodes[tree.root.current_node_id[]]
 
-    if active_set != nothing
-        node.active_set_size = length(active_set)
-    end
-
-    if use_DICG && pre_computed_set != nothing
-        node.discarded_set_size = length(pre_computed_set)
-    end
-
     if (state.primal - state.dual_gap > tree.incumbent + 1e-2) &&
        tree.num_nodes != 1 &&
        state.t > min_fw_iterations

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -109,6 +109,16 @@ function process_FW_callback_logic(
         end
     end
 
+    node = tree.nodes[tree.root.current_node_id[]]
+
+    if active_set != nothing
+        node.active_set_size = length(active_set)
+    end
+
+    if use_DICG && pre_computed_set != nothing
+        node.discarded_set_size = length(pre_computed_set)
+    end
+
     if (state.primal - state.dual_gap > tree.incumbent + 1e-2) &&
        tree.num_nodes != 1 &&
        state.t > min_fw_iterations

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -109,8 +109,6 @@ function process_FW_callback_logic(
         end
     end
 
-    node = tree.nodes[tree.root.current_node_id[]]
-
     if (state.primal - state.dual_gap > tree.incumbent + 1e-2) &&
        tree.num_nodes != 1 &&
        state.t > min_fw_iterations

--- a/src/node.jl
+++ b/src/node.jl
@@ -122,9 +122,6 @@ function Bonobo.get_branching_nodes_info(tree::Bonobo.BnBTree, node::FrankWolfeN
         error("Splitting on the same index as parent! Abort!")
     end
 
-    node.active_set_size = length(node.active_set)
-    node.discarded_set_size = length(node.discarded_vertices.storage)
-
     # get iterate, primal and lower bound
     x = Bonobo.get_relaxed_values(tree, node)
     primal = tree.root.problem.f(x)
@@ -300,6 +297,9 @@ Computes the relaxation at that node
 """
 function Bonobo.evaluate_node!(tree::Bonobo.BnBTree, node::FrankWolfeNode)
     # check that local bounds and global tightening don't conflict
+    node.active_set_size = length(node.active_set)
+    node.discarded_set_size = length(node.discarded_vertices)
+
     for (j, ub) in tree.root.global_tightenings.upper_bounds
         if !haskey(node.local_bounds.lower_bounds, j)
             continue

--- a/src/node.jl
+++ b/src/node.jl
@@ -297,9 +297,6 @@ Computes the relaxation at that node
 """
 function Bonobo.evaluate_node!(tree::Bonobo.BnBTree, node::FrankWolfeNode)
     # check that local bounds and global tightening don't conflict
-    node.active_set_size = length(node.active_set)
-    node.discarded_set_size = length(node.discarded_vertices)
-
     for (j, ub) in tree.root.global_tightenings.upper_bounds
         if !haskey(node.local_bounds.lower_bounds, j)
             continue
@@ -433,6 +430,9 @@ function Bonobo.evaluate_node!(tree::Bonobo.BnBTree, node::FrankWolfeNode)
     if tree.root.options[:ignore_lower_bound]
         return -Inf, NaN
     end
+
+    node.active_set_size = length(node.active_set)
+    node.discarded_set_size = length(node.discarded_vertices)
 
     return lower_bound, NaN
 end


### PR DESCRIPTION
The active set and shadow set sizes were being reported as 0 in example portfolio.jl. 